### PR TITLE
style: Header 및 Layout UI 구조 및 스타일 개선

### DIFF
--- a/src/domains/filter/apis/mockSearchApi.ts
+++ b/src/domains/filter/apis/mockSearchApi.ts
@@ -1,6 +1,6 @@
 // src/domains/filter/services/mockSearchApi.ts
 
-// 🎸 임시 데이터
+// 임시 데이터
 const mockResults = [
   { id: 1, name: "Fender Stratocaster", price: 1200000 },
   { id: 2, name: "Yamaha Drum Set", price: 800000 },
@@ -8,7 +8,7 @@ const mockResults = [
   { id: 4, name: "Gibson Les Paul", price: 1700000 },
 ];
 
-// 🧪 백엔드 API 대기 중: 가짜 검색 함수
+// 백엔드 API 대기 중: 가짜 검색 함수
 export async function searchProductsMock(keyword: string) {
   // API 지연 시뮬레이션
   await new Promise((resolve) => setTimeout(resolve, 400));

--- a/src/domains/filter/components/SearchBar.tsx
+++ b/src/domains/filter/components/SearchBar.tsx
@@ -1,0 +1,28 @@
+// src/domains/filter/components/SearchBar.tsx
+import { useState } from "react";
+import { Search } from "lucide-react";
+
+export default function SearchBar() {
+  const [keyword, setKeyword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("검색어:", keyword);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-center px-3 py-2 bg-gray-100 rounded-lg"
+    >
+      <Search className="w-4 h-4 text-gray-500" />
+      <input
+        type="text"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        placeholder="검색어를 입력하세요"
+        className="w-full ml-2 bg-transparent outline-none"
+      />
+    </form>
+  );
+}

--- a/src/domains/filter/components/SearchBar.tsx
+++ b/src/domains/filter/components/SearchBar.tsx
@@ -2,28 +2,34 @@
 import { FormEvent } from "react";
 import { Search } from "lucide-react";
 import { useSearch } from "../hooks/useSearch";
+import SearchResultList from "./SearchResultList"; // ✅ 추가
 
 export default function SearchBar() {
-  const { keyword, setKeyword, handleSearch } = useSearch();
+  const { keyword, setKeyword, handleSearch, results } = useSearch();
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    handleSearch(); // 🔍 실제 검색 실행
+    handleSearch();
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="flex items-center px-3 py-2 bg-gray-100 rounded-lg"
-    >
-      <Search className="w-4 h-4 text-gray-500" />
-      <input
-        type="text"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        placeholder="검색어를 입력하세요"
-        className="w-full ml-2 bg-transparent outline-none"
-      />
-    </form>
+    <div>
+      <form
+        onSubmit={handleSubmit}
+        className="flex items-center px-3 py-2 bg-gray-100 rounded-lg"
+      >
+        <Search className="w-4 h-4 text-gray-500" />
+        <input
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="검색어를 입력하세요"
+          className="w-full ml-2 bg-transparent outline-none"
+        />
+      </form>
+
+      {/* ✅ 검색 결과 표시 */}
+      <SearchResultList results={results} />
+    </div>
   );
 }

--- a/src/domains/filter/components/SearchBar.tsx
+++ b/src/domains/filter/components/SearchBar.tsx
@@ -1,8 +1,7 @@
-// src/domains/filter/components/SearchBar.tsx
 import { FormEvent } from "react";
 import { Search } from "lucide-react";
 import { useSearch } from "../hooks/useSearch";
-import SearchResultList from "./SearchResultList"; // ✅ 추가
+import SearchResultList from "./SearchResultList";
 
 export default function SearchBar() {
   const { keyword, setKeyword, handleSearch, results } = useSearch();
@@ -28,7 +27,7 @@ export default function SearchBar() {
         />
       </form>
 
-      {/* ✅ 검색 결과 표시 */}
+      {/* 검색 결과 표시 */}
       <SearchResultList results={results} />
     </div>
   );

--- a/src/domains/filter/components/SearchBar.tsx
+++ b/src/domains/filter/components/SearchBar.tsx
@@ -12,18 +12,19 @@ export default function SearchBar() {
   };
 
   return (
-    <div>
+    <div className="flex flex-col w-full gap-2">
+      {/* 검색창 */}
       <form
         onSubmit={handleSubmit}
-        className="flex items-center px-3 py-2 bg-gray-100 rounded-lg"
+        className="flex items-center w-full h-12 gap-2 px-4 bg-white shadow-md rounded-2xl"
       >
-        <Search className="w-4 h-4 text-gray-500" />
+        <Search className="w-5 h-5 text-gray-400" />
         <input
           type="text"
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
-          placeholder="검색어를 입력하세요"
-          className="w-full ml-2 bg-transparent outline-none"
+          placeholder="Search"
+          className="flex-1 text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none"
         />
       </form>
 

--- a/src/domains/filter/components/SearchBar.tsx
+++ b/src/domains/filter/components/SearchBar.tsx
@@ -1,13 +1,14 @@
 // src/domains/filter/components/SearchBar.tsx
-import { useState } from "react";
+import { FormEvent } from "react";
 import { Search } from "lucide-react";
+import { useSearch } from "../hooks/useSearch";
 
 export default function SearchBar() {
-  const [keyword, setKeyword] = useState("");
+  const { keyword, setKeyword, handleSearch } = useSearch();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    console.log("검색어:", keyword);
+    handleSearch(); // 🔍 실제 검색 실행
   };
 
   return (

--- a/src/domains/filter/components/SearchResultList.tsx
+++ b/src/domains/filter/components/SearchResultList.tsx
@@ -1,0 +1,29 @@
+// src/domains/filter/components/SearchResultList.tsx
+import React from "react";
+
+interface SearchResultListProps {
+  results: { id: number; name: string; price: number }[];
+}
+
+export default function SearchResultList({ results }: SearchResultListProps) {
+  if (!results.length)
+    return (
+      <p className="mt-4 text-sm text-center text-gray-500">
+        검색 결과가 없습니다.
+      </p>
+    );
+
+  return (
+    <ul className="mt-4 space-y-2">
+      {results.map((item) => (
+        <li
+          key={item.id}
+          className="flex justify-between p-3 border rounded-lg shadow-sm"
+        >
+          <span className="font-medium">{item.name}</span>
+          <span className="text-gray-600">₩ {item.price.toLocaleString()}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/domains/filter/components/SearchResultList.tsx
+++ b/src/domains/filter/components/SearchResultList.tsx
@@ -1,4 +1,3 @@
-// src/domains/filter/components/SearchResultList.tsx
 import React from "react";
 
 interface SearchResultListProps {

--- a/src/domains/filter/hooks/useSearch.ts
+++ b/src/domains/filter/hooks/useSearch.ts
@@ -1,0 +1,24 @@
+// src/domains/filter/hooks/useSearch.ts
+import { useState } from "react";
+import { searchProductsMock } from "../services/mockSearchApi";
+
+// 검색 관련 로직을 관리하는 훅
+export const useSearch = () => {
+  const [keyword, setKeyword] = useState("");
+  const [results, setResults] = useState<any[]>([]);
+
+  // 검색 실행 함수
+  const handleSearch = async () => {
+    if (!keyword.trim()) return;
+    const data = await searchProductsMock(keyword);
+    setResults(data);
+    console.log("검색 결과:", data); // ✅ 테스트용 콘솔 출력
+  };
+
+  return {
+    keyword,
+    setKeyword,
+    results,
+    handleSearch,
+  };
+};

--- a/src/domains/filter/hooks/useSearch.ts
+++ b/src/domains/filter/hooks/useSearch.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { searchProductsMock } from "../services/mockSearchApi";
+import { searchProductsMock } from "../apis/mockSearchApi";
 
 // 검색 관련 로직을 관리하는 훅
 export const useSearch = () => {

--- a/src/domains/filter/hooks/useSearch.ts
+++ b/src/domains/filter/hooks/useSearch.ts
@@ -1,4 +1,3 @@
-// src/domains/filter/hooks/useSearch.ts
 import { useState } from "react";
 import { searchProductsMock } from "../services/mockSearchApi";
 
@@ -12,7 +11,7 @@ export const useSearch = () => {
     if (!keyword.trim()) return;
     const data = await searchProductsMock(keyword);
     setResults(data);
-    console.log("검색 결과:", data); // ✅ 테스트용 콘솔 출력
+    console.log("검색 결과:", data); // 테스트용 콘솔 출력
   };
 
   return {

--- a/src/domains/filter/services/mockSearchApi.ts
+++ b/src/domains/filter/services/mockSearchApi.ts
@@ -1,0 +1,20 @@
+// src/domains/filter/services/mockSearchApi.ts
+
+// 🎸 임시 데이터
+const mockResults = [
+  { id: 1, name: "Fender Stratocaster", price: 1200000 },
+  { id: 2, name: "Yamaha Drum Set", price: 800000 },
+  { id: 3, name: "Korg Synthesizer", price: 1500000 },
+  { id: 4, name: "Gibson Les Paul", price: 1700000 },
+];
+
+// 🧪 백엔드 API 대기 중: 가짜 검색 함수
+export async function searchProductsMock(keyword: string) {
+  // API 지연 시뮬레이션
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  // keyword를 포함하는 데이터만 반환
+  return mockResults.filter((item) =>
+    item.name.toLowerCase().includes(keyword.toLowerCase())
+  );
+}

--- a/src/shares/layouts/Header.tsx
+++ b/src/shares/layouts/Header.tsx
@@ -1,16 +1,22 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Bell } from "lucide-react"; // 아이콘용
+// 나중에 SearchBar를 추가할 예정이에요.
+// import SearchBar from "@/domains/filter/components/SearchBar";
 
-//헤더 컴포넌트
-export function Header() {
+export default function Header() {
   return (
-    <header className="w-full h-16 bg-gray-100 flex items-center justify-between px-6 shadow-sm">
-      <h1 className="text-lg font-semibold">My App</h1>
-      <nav className="flex gap-4">
-        <Link to="/" className="hover:text-blue-500">
-          Home
-        </Link>
-      </nav>
+    <header className="flex flex-col gap-2 px-4 py-2 border-b border-gray-200">
+      {/* 상단 로고 + 알림 */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">RE:BUY</h1>
+        <button className="relative">
+          <Bell className="w-5 h-5 text-gray-700" />
+          <span className="absolute top-0 right-0 w-2 h-2 bg-red-500 rounded-full" />
+        </button>
+      </div>
+
+      {/* 검색창 자리 */}
+      <div>{/* <SearchBar /> */}</div>
     </header>
   );
 }

--- a/src/shares/layouts/Header.tsx
+++ b/src/shares/layouts/Header.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Bell } from "lucide-react"; // 아이콘용
-// 나중에 SearchBar를 추가할 예정이에요.
-// import SearchBar from "@/domains/filter/components/SearchBar";
+import SearchBar from "@/domains/filter/components/SearchBar";
 
 export default function Header() {
   return (
@@ -16,7 +15,7 @@ export default function Header() {
       </div>
 
       {/* 검색창 자리 */}
-      <div>{/* <SearchBar /> */}</div>
+      <SearchBar />
     </header>
   );
 }

--- a/src/shares/layouts/Header.tsx
+++ b/src/shares/layouts/Header.tsx
@@ -1,20 +1,22 @@
-import React from "react";
-import { Bell } from "lucide-react"; // 아이콘용
+import { Bell } from "lucide-react";
 import SearchBar from "@/domains/filter/components/SearchBar";
 
 export default function Header() {
   return (
-    <header className="flex flex-col gap-2 px-4 py-2 border-b border-gray-200">
+    <header className="flex flex-col gap-3 px-5 py-3 bg-white border-b border-gray-200">
       {/* 상단 로고 + 알림 */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold">RE:BUY</h1>
+        <h1 className="text-[22px] font-bold text-gray-900 tracking-tight">
+          RE:BUY
+        </h1>
+
         <button className="relative">
-          <Bell className="w-5 h-5 text-gray-700" />
-          <span className="absolute top-0 right-0 w-2 h-2 bg-red-500 rounded-full" />
+          <Bell className="w-6 h-6 text-gray-700" />
+          <span className="absolute top-0 right-0 w-2.5 h-2.5 bg-red-500 rounded-full" />
         </button>
       </div>
 
-      {/* 검색창 자리 */}
+      {/* 검색창 */}
       <SearchBar />
     </header>
   );

--- a/src/shares/layouts/Layout.tsx
+++ b/src/shares/layouts/Layout.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router-dom";
-import { Header } from "@/shares/layouts/Header";
+import Header from "@/shares/layouts/Header";
 import { Footer } from "@/shares/layouts/Footer";
 
 //레이아웃 컴포넌트

--- a/src/shares/layouts/Layout.tsx
+++ b/src/shares/layouts/Layout.tsx
@@ -2,15 +2,21 @@ import { Outlet } from "react-router-dom";
 import Header from "@/shares/layouts/Header";
 import { Footer } from "@/shares/layouts/Footer";
 
-//레이아웃 컴포넌트
+// 전체 레이아웃 컴포넌트
 export function Layout() {
   return (
-    <>
+    // 모바일에서는 꽉 차게, 웹에서는 672px로 고정 + 중앙 정렬
+    <div className="flex flex-col w-full max-w-2xl min-h-screen mx-auto bg-white">
+      {/* 헤더 */}
       <Header />
-      <main className="min-h-[calc(100vh-200px)] px-4 py-8">
-        <Outlet /> {/* 각 페이지가 여기로 들어감 */}
+
+      {/* 메인 콘텐츠 영역 */}
+      <main className="flex-1 min-h-[calc(100vh-200px)] px-4 py-8">
+        <Outlet /> {/* 각 페이지 내용 */}
       </main>
+
+      {/* 푸터 */}
       <Footer />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## 작업 내용
- 디자인 시안에 맞춰 Header 및 SearchBar UI 수정
- 로고, 알림 아이콘, 검색창 레이아웃 정렬 및 여백 조정
- 전체 페이지 폭을 모바일 기준(672px, max-w-2xl)으로 고정하여 일관된 화면 유지

## 변경 사항
- `src/shares/layouts/Header.tsx`  
  - 로고 폰트 굵기 `font-bold`로 변경  
  - 알림 아이콘 크기 및 위치 보정  
  - SearchBar 스타일 (흰색 배경, 그림자, 둥근 모서리) 적용
- `src/shares/layouts/Layout.tsx`  
  - 모바일 중심 레이아웃으로 구조 변경 (`max-w-2xl` 적용)
  - 페이지 중앙 정렬 및 배경 정리

## 테스트 방법
1. `npm run dev` 실행  
2. `/` 경로 진입 후 UI 확인  
   - Header와 SearchBar가 시안과 동일하게 표시되는지 확인  
   - 데스크톱 환경에서 폭 672px로 중앙 정렬 유지 확인  

## 관련 이슈
- Closes #9 
