### PR TITLE
feat: 하단 네비게이션 전용 페이지 추가 및 Footer 라우팅 연결

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,10 @@
 import { HomePage } from "@/pages/HomePage";
 import { Layout } from "@/shares/layouts/Layout";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import CommunityPage from "@/pages/CommunityPage";
+import MapPage from "@/pages/MapPage";
+import ChatPage from "@/pages/ChatPage";
+import ProfilePage from "@/pages/ProfilePage";
 
 function AppContent() {
   return (
@@ -11,7 +15,10 @@ function AppContent() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<HomePage />} />
-          <Route path="/login" element={<div>Login Page</div>} />
+          <Route path="/community" element={<CommunityPage />} />
+          <Route path="/map" element={<MapPage />} />
+          <Route path="/chat" element={<ChatPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
         </Route>
       </Routes>
     </div>

--- a/src/domains/filter/components/SearchBar.tsx
+++ b/src/domains/filter/components/SearchBar.tsx
@@ -28,8 +28,10 @@ export default function SearchBar() {
         />
       </form>
 
-      {/* 검색 결과 표시 */}
-      <SearchResultList results={results} />
+      {keyword && (
+       <SearchResultList results={results} />
+      )}
+
     </div>
   );
 }

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,0 +1,3 @@
+export default function CommunityPage() {
+  return <div className="p-4">채팅 페이지 (CommunityPage)</div>;
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,3 +1,3 @@
-export default function CommunityPage() {
-  return <div className="p-4">채팅 페이지 (CommunityPage)</div>;
+export default function ChatPage() {
+  return <div className="p-4">채팅 페이지 (ChatPage)</div>;
 }

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -1,0 +1,3 @@
+export default function CommunityPage() {
+  return <div className="p-4">커뮤니티 페이지 (CommunityPage)</div>;
+}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,0 +1,3 @@
+export default function CommunityPage() {
+  return <div className="p-4">지도 페이지 (CommunityPage)</div>;
+}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,3 +1,3 @@
-export default function CommunityPage() {
-  return <div className="p-4">지도 페이지 (CommunityPage)</div>;
+export default function MapPage() {
+  return <div className="p-4">지도 페이지 (MapPage)</div>;
 }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,3 @@
+export default function CommunityPage() {
+  return <div className="p-4">프로필 페이지 (CommunityPage)</div>;
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,3 +1,3 @@
-export default function CommunityPage() {
-  return <div className="p-4">프로필 페이지 (CommunityPage)</div>;
+export default function ProfilePage() {
+  return <div className="p-4">프로필 페이지 (ProfilePage)</div>;
 }

--- a/src/shares/layouts/Footer.tsx
+++ b/src/shares/layouts/Footer.tsx
@@ -1,38 +1,40 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Home, Users, MapPin, MessageCircle, User } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 //푸터 컴포넌트
 export function Footer() {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const navItems = [
+    { icon: <Users size={22} />, path: "/community" },
+    { icon: <MapPin size={22} />, path: "/map" },
+    { icon: <Home size={22} />, path: "/" },
+    { icon: <MessageCircle size={22} />, path: "/chat" },
+    { icon: <User size={22} />, path: "/profile" },
+  ];
 
   return (
-    <footer className="w-full h-16 bg-gray-800 text-white flex items-center justify-center">
-      <div className="flex space-x-4">
-        <button
-          onClick={() => navigate("/")}
-          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition"
-        >
-          Home
-        </button>
-        <button
-          onClick={() => navigate("/about")}
-          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition"
-        >
-          About
-        </button>
-        <button
-          onClick={() => navigate("/contact")}
-          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition"
-        >
-          Contact
-        </button>
-        <button
-          onClick={() => navigate("/login")}
-          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition"
-        >
-          Login
-        </button>
-      </div>
-    </footer>
+    <div className="w-full flex justify-center fixed bottom-0 left-1/2 -translate-x-1/2 bg-white border-t border-gray-200 shadow-md">
+      <footer className="w-full max-w-2xl">
+        <nav className="flex justify-around py-3">
+          {navItems.map(({ icon, path }, index) => (
+            <button
+              key={index}
+              onClick={() => navigate(path)}
+              className={`flex flex-col items-center ${
+                location.pathname === path ? "text-black" : "text-gray-400"
+              }`}
+            >
+              {icon}
+            </button>
+          ))}
+        </nav>
+        <div className="flex justify-center mt-1">
+          <div className="w-12 h-1 bg-gray-300 rounded-full" />
+        </div>
+      </footer>
+    </div>
   );
 }

--- a/src/shares/layouts/Layout.tsx
+++ b/src/shares/layouts/Layout.tsx
@@ -5,18 +5,24 @@ import { Footer } from "@/shares/layouts/Footer";
 // 전체 레이아웃 컴포넌트
 export function Layout() {
   return (
-    // 모바일에서는 꽉 차게, 웹에서는 672px로 고정 + 중앙 정렬
-    <div className="flex flex-col w-full max-w-2xl min-h-screen mx-auto bg-white">
-      {/* 헤더 */}
-      <Header />
+    <div className="flex justify-center w-full min-h-screen bg-gray-50">
+      {/* 중앙 고정된 672px 박스 */}
+      <div className="relative flex flex-col w-[672px] min-h-screen bg-white">
+        {/* 헤더 */}
+        <header className="sticky top-0 z-50 bg-white border-b border-gray-200">
+          <Header />
+        </header>
 
-      {/* 메인 콘텐츠 영역 */}
-      <main className="flex-1 min-h-[calc(100vh-200px)] px-4 py-8">
-        <Outlet /> {/* 각 페이지 내용 */}
-      </main>
+        {/* 메인 */}
+        <main className="flex-1 overflow-y-auto px-4 py-8">
+          <Outlet />
+        </main>
 
-      {/* 푸터 */}
-      <Footer />
+        {/* 푸터 */}
+        <footer className="w-full border-t border-gray-200 bg-white">
+          <Footer />
+        </footer>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 작업 내용
- Footer 네비게이션과 연결되는 페이지 4개 추가 (Community, Map, Chat, Profile)
- Footer.tsx 내 각 아이콘 라우팅 로직 수정 및 연결
- App.tsx, Layout.tsx 구조 일부 수정으로 전체 라우팅 반영

## 변경 사항
- src/pages/CommunityPage.tsx
- src/pages/MapPage.tsx
- src/pages/ChatPage.tsx
- src/pages/ProfilePage.tsx
- src/shares/layouts/Footer.tsx 수정
- src/shares/layouts/Layout.tsx 수정
- src/app/App.tsx 수정

## 테스트 방법
1. `npm run dev` 실행
2. 하단 네비게이션의 각 아이콘 클릭 시 해당 페이지로 이동되는지 확인
3. 현재 페이지의 아이콘만 진하게 표시되는지 확인

## 관련 이슈
- Closes #12
